### PR TITLE
Rhel9 is using s-nail instead of mailx

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ tls_append_default_CA = yes
 Version
 -------
 
+* `3.1.0` --- support RHEL9 using `s-nail` 
 * `3.0.0` --- update to ansible 2.12.9
 * `2.3.0` --- added RHEL9 and CentOS Stream 8 support.
 * `2.2.0` --- added Ubuntu Jammy(22.04) and removed centos8.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,7 @@
     name:
       - postfix
       - ca-certificates
-      - '{{ "mailx" if ansible_os_family | lower == "redhat" else "bsd-mailx" }}'
+      - '{{ "mailx" if ansible_os_family | lower == "redhat" and ansible_distribution_version|int in [7, 8] else "s-nail" if ansible_os_family | lower == "redhat" and ansible_distribution_version|int in [9] else "bsd-mailx" }}'
     state: present
   when:
     - not ansible_check_mode


### PR DESCRIPTION
Hi!

I'd like to contribute the following feature.

`mailx` on rhel9 is replaced with s-nail. 

I confirm that my contributions will be compatible with the GPLv2.0 license guidelines.

* [X] I have read and accepted both license and code of conduct.
* [X] I have previously accepted and still accept both license and code of conduct.
